### PR TITLE
  Additions for ORA2 instructor override score feature.

### DIFF
--- a/submissions/models.py
+++ b/submissions/models.py
@@ -205,6 +205,26 @@ class Score(models.Model):
             reset=True,
         )
 
+    @classmethod
+    def create_override_score(cls, student_item_model, points_override, points_possible):
+        """
+        Create an "override" score (a score with a null submission and reset False).
+
+        Args:
+            student_item_model (StudentItem): The student item model.
+            points_override (string): The points provided by the instructor to override
+            points_possible (string): The max points possible for this submission.
+            any existing score.
+
+        """
+
+        return cls.objects.create(
+            student_item=student_item_model,
+            submission=None,
+            points_earned=float(points_override),
+            points_possible=float(points_possible),
+        )
+
     def __unicode__(self):
         return u"{0.points_earned}/{0.points_possible}".format(self)
 

--- a/submissions/tests/test_models.py
+++ b/submissions/tests/test_models.py
@@ -164,3 +164,39 @@ class TestScoreSummary(TestCase):
         highest = ScoreSummary.objects.get(student_item=item).highest
         self.assertEqual(highest.points_earned, 1)
         self.assertEqual(highest.points_possible, 2)
+
+    def test_override_highest_no_score(self):
+        item = StudentItem.objects.create(
+            student_id="score_test_student",
+            course_id="score_test_course",
+            item_id="i4x://mycourse/special_presentation",
+        )
+
+        # Override score with no score
+        Score.create_override_score(item, 9, 10)
+        highest = ScoreSummary.objects.get(student_item=item).highest
+        self.assertEqual(highest.points_earned, 9)
+        self.assertEqual(highest.points_possible, 10)
+
+    def test_override_highest_with_score(self):
+        item = StudentItem.objects.create(
+            student_id="score_test_student",
+            course_id="score_test_course",
+            item_id="i4x://mycourse/special_presentation",
+        )
+        # Override score after a non-reset score
+        submission = Submission.objects.create(
+            student_item=item,
+            attempt_number=1,
+        )
+        Score.objects.create(
+            student_item=item,
+            submission=submission,
+            points_earned=1,
+            points_possible=15,
+        )
+
+        Score.create_override_score(item, 5, 15)
+        highest = ScoreSummary.objects.get(student_item=item).highest
+        self.assertEqual(highest.points_earned, 5)
+        self.assertEqual(highest.points_possible, 15)

--- a/submissions/tests/test_override_score.py
+++ b/submissions/tests/test_override_score.py
@@ -1,0 +1,114 @@
+"""
+Test override scores.
+"""
+
+from mock import patch
+from django.test import TestCase
+from django.core.cache import cache
+from django.db import DatabaseError
+from submissions import api as sub_api
+from submissions.models import Score
+
+
+class TestOverrideScore(TestCase):
+    """
+    Test overriding scores for a specific student on a specific problem.
+    """
+
+    STUDENT_ITEM = {
+        'student_id': 'Test student',
+        'course_id': 'Test course',
+        'item_id': 'Test item',
+        'item_type': 'Test item type',
+    }
+
+    def setUp(self):
+        """
+        Clear the cache.
+        """
+        cache.clear()
+
+    def test_override_with_no_score(self):
+
+        sub_api.score_override(
+            self.STUDENT_ITEM,
+            8,
+            10,
+        )
+
+        self.assertEqual(sub_api.get_score(self.STUDENT_ITEM)['points_earned'], 8)
+        self.assertEqual(sub_api.get_score(self.STUDENT_ITEM)['points_possible'], 10)
+
+    def test_override_with_one_score(self):
+        # Create a submission for the student and score it
+        submission = sub_api.create_submission(self.STUDENT_ITEM, 'test answer')
+        sub_api.set_score(submission['uuid'], 1, 10)
+
+        sub_api.score_override(
+            self.STUDENT_ITEM,
+            5,
+            10,
+        )
+
+        self.assertEqual(sub_api.get_score(self.STUDENT_ITEM)['points_earned'], 5)
+        self.assertEqual(sub_api.get_score(self.STUDENT_ITEM)['points_possible'], 10)
+
+    def test_override_after_reset_score(self):
+        # Create a submission for the student and score it
+        submission = sub_api.create_submission(self.STUDENT_ITEM, 'test answer')
+        sub_api.set_score(submission['uuid'], 1, 10)
+
+        # Reset score
+        sub_api.reset_score(
+            self.STUDENT_ITEM['student_id'],
+            self.STUDENT_ITEM['course_id'],
+            self.STUDENT_ITEM['item_id'],
+        )
+
+        sub_api.score_override(
+            self.STUDENT_ITEM,
+            5,
+            10,
+        )
+
+        self.assertEqual(sub_api.get_score(self.STUDENT_ITEM)['points_earned'], 5)
+        self.assertEqual(sub_api.get_score(self.STUDENT_ITEM)['points_possible'], 10)
+
+    @patch.object(Score.objects, 'create')
+    def test_database_error(self, create_mock):
+        # Simulate a database error when creating the override score
+        create_mock.side_effect = DatabaseError('Test error')
+        with self.assertRaises(sub_api.SubmissionInternalError):
+            sub_api.score_override(
+                self.STUDENT_ITEM,
+                7,
+                10,
+            )
+
+    def test_override_doesnt_overwrite_submission_score(self):
+        # Create a submission for the student and score it
+        submission = sub_api.create_submission(self.STUDENT_ITEM, 'test answer')
+        sub_api.set_score(submission['uuid'], 1, 10)
+
+        sub_api.score_override(
+            self.STUDENT_ITEM,
+            8,
+            10,
+        )
+
+        submission_score = sub_api.get_latest_score_for_submission(submission['uuid'])
+        self.assertEqual(submission_score['points_earned'], 1)
+        self.assertEqual(submission_score['points_possible'], 10)
+
+        override_score = sub_api.get_score_override(self.STUDENT_ITEM)
+        self.assertEqual(override_score['points_earned'], 8)
+        self.assertEqual(override_score['points_possible'], 10)
+
+    def test_get_override_when_no_override(self):
+        sub_api.create_submission(self.STUDENT_ITEM, 'test answer')
+        override_score = sub_api.get_score_override(self.STUDENT_ITEM)
+        self.assertIsNone(override_score)
+
+    def test_get_override_when_no_studentItem(self):
+        override_score = sub_api.get_score_override(self.STUDENT_ITEM)
+        self.assertIsNone(override_score)


### PR DESCRIPTION
```
ORA2 has been modified in a seperate PR to include functionality
allowing the instructor to override a student's ORA score.

This override score is stored in Submissions as a Score without
a related submission. API methods have been added to create and
get the override score.
```

"
